### PR TITLE
fixed masked date input, added display date format, that determines t…

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "contributors": [
     "Joel Meiller <joel@oscillate.ch>"
   ],
-  "version": "3.6.54",
+  "version": "3.6.55",
   "keywords": [],
   "scripts": {
     "build": "tsc",

--- a/src/components/FormattedDatePicker.tsx
+++ b/src/components/FormattedDatePicker.tsx
@@ -6,6 +6,9 @@ export type Props = {
   onChange: (value: string | null) => void
   onBlur: (value: string | null) => void
   value: string | null
+  /**
+   * The date format that the input string is in
+   */
   dateFormat: string
 } & Omit<DatePickerProps, 'onChange' | 'onBlur' | 'value'>
 

--- a/src/components/MaskedDatePicker.tsx
+++ b/src/components/MaskedDatePicker.tsx
@@ -22,8 +22,19 @@ import {
 import { MdOutlineCalendarToday } from '../icons/new/MdOutlineCalendarToday'
 
 export type Props = {
+  /**
+   * The date value: Has to be in a format that new Date(value) can parse correctly
+   */
+  value: string | null
   dataTestId?: string
-  dateFormat?: string
+  /**
+   * The date format that the input string is in
+   */
+  dateFormat: string
+  /**
+   * Sometimes the date format that the server expects is different from the one that the user sees.
+   */
+  displayDateFormat?: string
   datePickerProps?: Partial<Omit<ReactDatePickerProps, 'onChange' | 'selected' | 'value'>>
   error?: boolean
   hasFocus?: boolean
@@ -33,7 +44,6 @@ export type Props = {
   onFocus?: () => void
   onBlur: (value: string) => void
   style?: Partial<ComponentTheme['datePicker']>
-  value: string | null
   maskInput?: {
     alwaysShowMask?: boolean
     mask?: string
@@ -119,7 +129,7 @@ export const MaskedDatePicker = (props: Props) => {
     !!props.value &&
     parseDate(props.value, dateFormat) !== 'Invalid Date' &&
     isValid(parseDate(props.value, dateFormat))
-      ? props.value
+      ? format(parseDate(props.value, dateFormat) as Date, props.displayDateFormat || dateFormat)
       : null
   const parsedDate = parseDate(props.value, dateFormat)
 

--- a/src/form/components/FieldItemReadOnly.tsx
+++ b/src/form/components/FieldItemReadOnly.tsx
@@ -48,10 +48,13 @@ const defaultDateStringMapper = ({
   value,
   language,
   dateFormat,
-}: MapperParams<string | null> & { dateFormat?: string }): string => {
+  displayDateFormat,
+}: MapperParams<string | null> & { dateFormat: string; displayDateFormat?: string }): string => {
   const locale = mapLanguageToLocale[language]
   const parsedDate = parse(value, dateFormat ?? 'dd.MM.yyyy', new Date(), { locale })
-  return value && isValid(parsedDate) ? format(parsedDate, dateFormat ?? 'dd.MM.yyyy', { locale }) : ''
+  return value && isValid(parsedDate)
+    ? format(parsedDate, displayDateFormat ?? dateFormat ?? 'dd.MM.yyyy', { locale })
+    : ''
 }
 
 const defaultBooleanMapper = ({ value, translate }: MapperParams<boolean>): string =>


### PR DESCRIPTION
…he display format when the underlying format is different

@joelmeiller what do you think? It seems kinda stupid, but the problem was that backend only understands the format MM.dd.yyyy, but we want to display dd.MM.yyyy. So in such a case one would say dateFormat: MM.dd.yyyy for the input and output to be parsed correctly. And dd.MM.yyyy for the displayDateFormat.